### PR TITLE
feat: dynamic worker nodes configuration

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -114,6 +114,25 @@ Type: `string`
 
 Default: `"v1.26.0"`
 
+==== [[input_nodes]] <<input_nodes,nodes>>
+
+Description: List of nodes
+
+Type: `list(map(string))`
+
+Default:
+[source,json]
+----
+[
+  {
+    "platform": "devops-stack"
+  },
+  {
+    "platform": "devops-stack"
+  }
+]
+----
+
 === Outputs
 
 The following outputs are exported:
@@ -179,6 +198,25 @@ Description: Raw `.kube/config` file for `kubectl` access.
 |Kubernetes version to use for the KinD cluster (images available https://hub.docker.com/r/kindest/node/tags[here]).
 |`string`
 |`"v1.26.0"`
+|no
+
+|[[input_nodes]] <<input_nodes,nodes>>
+|List of nodes
+|`list(map(string))`
+|
+
+[source]
+----
+[
+  {
+    "platform": "devops-stack"
+  },
+  {
+    "platform": "devops-stack"
+  }
+]
+----
+
 |no
 
 |===

--- a/main.tf
+++ b/main.tf
@@ -10,12 +10,13 @@ resource "kind_cluster" "cluster" {
     node {
       role = "control-plane"
     }
-    # TODO variable for worker nodes with labels.
-    node {
-      role = "worker"
-    }
-    node {
-      role = "worker"
+
+    dynamic "node" {
+      for_each = var.nodes
+      content {
+        role   = "worker"
+        labels = node.value
+      }
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -9,3 +9,16 @@ variable "kubernetes_version" {
   type        = string
   default     = "v1.26.0"
 }
+
+variable "nodes" {
+  description = "List of nodes"
+  type        = list(map(string))
+  default = [
+    {
+      "platform" = "devops-stack"
+    },
+    {
+      "platform" = "devops-stack"
+    }
+  ]
+}


### PR DESCRIPTION
This PR allows dynamic configuration of worker nodes and their labels.
If we don't set `nodes` input, two default worker nodes are created with the label `platform = devops-stack`.