### PR TITLE
fix: set KinD provider version to 0.1.0 and onwards

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -70,13 +70,13 @@ The following requirements are needed by this module:
 
 - [[requirement_docker]] <<requirement_docker,docker>> (>= 2.23.1)
 
-- [[requirement_kind]] <<requirement_kind,kind>> (0.0.17)
+- [[requirement_kind]] <<requirement_kind,kind>> (>= 0.1.0)
 
 === Providers
 
 The following providers are used by this module:
 
-- [[provider_kind]] <<provider_kind,kind>> (0.0.17)
+- [[provider_kind]] <<provider_kind,kind>> (>= 0.1.0)
 
 - [[provider_docker]] <<provider_docker,docker>> (>= 2.23.1)
 
@@ -84,7 +84,7 @@ The following providers are used by this module:
 
 The following resources are used by this module:
 
-- https://registry.terraform.io/providers/tehcyx/kind/0.0.17/docs/resources/cluster[kind_cluster.cluster] (resource)
+- https://registry.terraform.io/providers/tehcyx/kind/latest/docs/resources/cluster[kind_cluster.cluster] (resource)
 - https://registry.terraform.io/providers/kreuzwerker/docker/latest/docs/data-sources/network[docker_network.kind] (data source)
 
 === Optional Inputs
@@ -158,7 +158,7 @@ Description: Kind IPv4 Docker network subnet.
 |===
 |Name |Version
 |[[requirement_docker]] <<requirement_docker,docker>> |>= 2.23.1
-|[[requirement_kind]] <<requirement_kind,kind>> |0.0.17
+|[[requirement_kind]] <<requirement_kind,kind>> |>= 0.1.0
 |===
 
 = Providers
@@ -166,7 +166,7 @@ Description: Kind IPv4 Docker network subnet.
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_kind]] <<provider_kind,kind>> |0.0.17
+|[[provider_kind]] <<provider_kind,kind>> |>= 0.1.0
 |[[provider_docker]] <<provider_docker,docker>> |>= 2.23.1
 |===
 
@@ -175,7 +175,7 @@ Description: Kind IPv4 Docker network subnet.
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Type
-|https://registry.terraform.io/providers/tehcyx/kind/0.0.17/docs/resources/cluster[kind_cluster.cluster] |resource
+|https://registry.terraform.io/providers/tehcyx/kind/latest/docs/resources/cluster[kind_cluster.cluster] |resource
 |https://registry.terraform.io/providers/kreuzwerker/docker/latest/docs/data-sources/network[docker_network.kind] |data source
 |===
 

--- a/terraform.tf
+++ b/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     kind = {
       source  = "tehcyx/kind"
-      version = "0.0.17"
+      version = ">= 0.1.0"
     }
     docker = {
       source  = "kreuzwerker/docker"


### PR DESCRIPTION
## Description of the changes

The upstream bug is fixed on tehcyx/terraform-provider-kind, we can use the updated versions again.

## Breaking change

- [x] No
- [ ] Yes
