### PR TITLE
feat/fix/docs: update default Kubernetes version, add validation to nodes variable and update documentation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -2,9 +2,11 @@
 
 A https://devops-stack.io[DevOps Stack] module to deploy a KinD cluster based on Docker.
 
-This cluster module is mainly used to deploy a *single-node* Kubernetes cluster used for testing and development as well as for onboarding new users of the DevOps Stack.
+This cluster module is mainly used to deploy a Kubernetes cluster used for testing and development as well as for onboarding new users of the DevOps Stack.
 
-Because KinD is nothing more than a Kubernetes cluster running inside a container, it is required that you have Docker up and running on your machine (the documentation to install Docker is available here https://docs.docker.com/engine/install/[here]).
+KinD is nothing more than a local Kubernetes cluster using Docker container "nodes". As such, it is required that you have Docker up and running on your machine (the documentation to install Docker is available here https://docs.docker.com/engine/install/[here]).
+
+TIP: An example of a deployment of the DevOps Stack using KinD is available https://github.com/camptocamp/devops-stack/tree/main/examples/kind[here] as well as an accompanying xref:ROOT:tutorials/deploy_aks.adoc[quick tutorial].
 
 == Usage
 
@@ -28,11 +30,11 @@ module "kind" {
 
   cluster_name = local.cluster_name
 
-  kubernetes_version = "1.25.3"
+  kubernetes_version = "1.27.3"
 }
 ----
 
-It is also possible to configure the ports that are mapped between the KinD container and your machine. This is needed in order to access services that you deploy inside the cluster. By default, this module already maps the ports needed for HTTP and HTTPS traffic.
+By default, this module deploys a cluster with a control plane node and 3 worker nodes. If you want to deploy one more worker node, you can do it like this:
 
 [source,terraform]
 ----
@@ -41,12 +43,22 @@ module "kind" {
 
   cluster_name = local.cluster_name
 
-  extra_port_mappings = ["tcp/22", "udp/53"]
+  nodes = [
+    {
+      "platform" = "devops-stack"
+    },
+    {
+      "platform" = "devops-stack"
+    },
+    {
+      "platform" = "devops-stack"
+    },
+    {
+      "platform" = "devops-stack"
+    },
+  ]
 }
 ----
-
-// This link does not have a working example before we have merged the v1 branch to master.
-TIP: A test deployment of the DevOps Stack is available https://github.com/camptocamp/devops-stack/tree/master/tests/kind-kind[here].
 
 == Technical Reference
 
@@ -57,9 +69,10 @@ Obviously, since this module deploys the cluster, it does not depend on any othe
 [source,terraform]
 ----
 locals {
-  cluster_name     = "gh-v1-cluster"
-  cluster_issuer   = "ca-issuer"
-  argocd_namespace = "argocd"
+  kubernetes_version     = "v1.27.3"
+  cluster_name           = "YOUR_CLUSTER_NAME"
+  base_domain            = format("%s.nip.io", replace(module.traefik.external_ip, ".", "-"))
+  cluster_issuer         = "ca-issuer"
 }
 ----
 

--- a/README.adoc
+++ b/README.adoc
@@ -118,11 +118,11 @@ Description: Kubernetes version to use for the KinD cluster (images available ht
 
 Type: `string`
 
-Default: `"v1.26.0"`
+Default: `"v1.27.3"`
 
 ==== [[input_nodes]] <<input_nodes,nodes>>
 
-Description: List of nodes
+Description: List of worker nodes to create in the KinD cluster. To increase the number of nodes, simply duplicate the objects on the list.
 
 Type: `list(map(string))`
 
@@ -206,11 +206,11 @@ Description: Kind IPv4 Docker network subnet.
 |[[input_kubernetes_version]] <<input_kubernetes_version,kubernetes_version>>
 |Kubernetes version to use for the KinD cluster (images available https://hub.docker.com/r/kindest/node/tags[here]).
 |`string`
-|`"v1.26.0"`
+|`"v1.27.3"`
 |no
 
 |[[input_nodes]] <<input_nodes,nodes>>
-|List of nodes
+|List of worker nodes to create in the KinD cluster. To increase the number of nodes, simply duplicate the objects on the list.
 |`list(map(string))`
 |
 

--- a/variables.tf
+++ b/variables.tf
@@ -7,7 +7,7 @@ variable "cluster_name" {
 variable "kubernetes_version" {
   description = "Kubernetes version to use for the KinD cluster (images available https://hub.docker.com/r/kindest/node/tags[here])."
   type        = string
-  default     = "v1.26.0"
+  default     = "v1.27.3"
 }
 
 variable "nodes" {

--- a/variables.tf
+++ b/variables.tf
@@ -11,7 +11,7 @@ variable "kubernetes_version" {
 }
 
 variable "nodes" {
-  description = "List of nodes"
+  description = "List of worker nodes to create in the KinD cluster. To increase the number of nodes, simply duplicate the objects on the list."
   type        = list(map(string))
   default = [
     {

--- a/variables.tf
+++ b/variables.tf
@@ -22,6 +22,11 @@ variable "nodes" {
     },
     {
       "platform" = "devops-stack"
-    }
+    },
   ]
+
+  validation {
+    condition     = length(var.nodes) >= 3
+    error_message = "A minimum of 3 nodes is required because of the way the other DevOps Stack modules are configured."
+  }
 }


### PR DESCRIPTION
## Description of the changes

- Updates the default Kubernetes version;
- Updates the README.adoc and fixes issue #13;
- Adds a validation rule to the `nodes` variable, because the DevOps Stack does not support fewer than 3 worker nodes;

:warning: **Do a _Rebase and merge_ and close the related issue when merged.**

## Breaking change

- [x] No
