### PR TITLE
feat: update the default Kubernetes version

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -118,7 +118,7 @@ Description: Kubernetes version to use for the KinD cluster (images available ht
 
 Type: `string`
 
-Default: `"v1.27.3"`
+Default: `"v1.29.0"`
 
 ==== [[input_nodes]] <<input_nodes,nodes>>
 
@@ -206,7 +206,7 @@ Description: Kind IPv4 Docker network subnet.
 |[[input_kubernetes_version]] <<input_kubernetes_version,kubernetes_version>>
 |Kubernetes version to use for the KinD cluster (images available https://hub.docker.com/r/kindest/node/tags[here]).
 |`string`
-|`"v1.27.3"`
+|`"v1.29.0"`
 |no
 
 |[[input_nodes]] <<input_nodes,nodes>>

--- a/variables.tf
+++ b/variables.tf
@@ -7,7 +7,7 @@ variable "cluster_name" {
 variable "kubernetes_version" {
   description = "Kubernetes version to use for the KinD cluster (images available https://hub.docker.com/r/kindest/node/tags[here])."
   type        = string
-  default     = "v1.27.3"
+  default     = "v1.29.0"
 }
 
 variable "nodes" {


### PR DESCRIPTION
## Description of the changes

This PR upgrades the default Kubernetes version from v1.27.3 to v1.29.0

## Breaking change

- [x] No
